### PR TITLE
Ability to check entity state, not only whether exists

### DIFF
--- a/src/EntityExist.php
+++ b/src/EntityExist.php
@@ -11,7 +11,7 @@ use Symfony\Component\Validator\Constraint;
  *
  * @author Radoje Albijanic <radoje.albijanic@gmail.com>
  */
-final class EntityExist extends Constraint
+class EntityExist extends Constraint
 {
     public $message = 'Entity "%entity%" with property "%property%": "%value%" does not exist.';
     public $property = 'id';

--- a/src/EntityExistValidator.php
+++ b/src/EntityExistValidator.php
@@ -11,8 +11,9 @@ use Symfony\Component\Validator\ConstraintValidator;
 /**
  * @author Tobias Nyholm <tobias.nyholm@gmail.com>
  * @author Radoje Albijanic <radoje@blackmountainlabs.me>
+ * @author Marcin Morawski <marcin@morawskim.pl>
  */
-final class EntityExistValidator extends ConstraintValidator
+class EntityExistValidator extends ConstraintValidator
 {
     private $entityManager;
 
@@ -39,12 +40,17 @@ final class EntityExistValidator extends ConstraintValidator
             $constraint->property => $value,
         ]);
 
-        if (null === $data) {
+        if (null === $data || !$this->checkEntity($data)) {
             $this->context->buildViolation($constraint->message)
                 ->setParameter('%entity%', $constraint->entity)
                 ->setParameter('%property%', $constraint->property)
                 ->setParameter('%value%', (string) $value)
                 ->addViolation();
         }
+    }
+
+    protected function checkEntity(object $entity): bool
+    {
+        return true;
     }
 }


### PR DESCRIPTION
Hello,

In some cases, we might need to check not only whether the entity exists, but also the state (for example is an article published).
This PR allows easily extend the default implementation for also check the entity state.

Everything is based on the Template method design pattern so require only extends the base class.
The default implementation always returns true, so each entity is valid. 
Users can overwrite this method and also inject more services to validate the state of the fetched entity.
That is why I needed to remove the final keywords from the constraint and validator classes.