### PR TITLE
Feature/php8 attribute

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,8 +1,8 @@
 {
   "name": "happyr/entity-exists-validation-constraint",
-  "type": "library",
   "description": "Verify that your entity exists",
   "license": "MIT",
+  "type": "library",
   "authors": [
     {
       "name": "Radoje Albijanic",

--- a/src/EntityExist.php
+++ b/src/EntityExist.php
@@ -11,9 +11,19 @@ use Symfony\Component\Validator\Constraint;
  *
  * @author Radoje Albijanic <radoje.albijanic@gmail.com>
  */
+#[\Attribute(\Attribute::TARGET_PROPERTY)]
 final class EntityExist extends Constraint
 {
     public $message = 'Entity "%entity%" with property "%property%": "%value%" does not exist.';
     public $property = 'id';
     public $entity;
+
+    public function __construct($entity = null, $property = null, $message = null, $options = null, array $groups = null, $payload = null)
+    {
+        parent::__construct($options, $groups, $payload);
+
+        $this->entity = $entity ?? $this->entity;
+        $this->property = $property ?? $this->property;
+        $this->message = $message ?? $this->message;
+    }
 }

--- a/tests/EntityExistValidatorTest.php
+++ b/tests/EntityExistValidatorTest.php
@@ -166,6 +166,11 @@ class EntityExistValidatorTest extends TestCase
      */
     public function testValidateFromAttribute()
     {
+        $numRequired = (new \ReflectionMethod(AnnotationLoader::class, '__construct'))->getNumberOfRequiredParameters();
+        if ($numRequired > 0) {
+            $this->markTestSkipped('This test is skipped on Symfony <5.2');
+        }
+
         $this->context->expects($this->never())->method('buildViolation');
 
         $classMetadata = new ClassMetadata(EntityDummy::class);

--- a/tests/EntityExistValidatorTest.php
+++ b/tests/EntityExistValidatorTest.php
@@ -12,6 +12,8 @@ use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Validator\Constraints\NotNull;
 use Symfony\Component\Validator\Context\ExecutionContextInterface;
+use Symfony\Component\Validator\Mapping\ClassMetadata;
+use Symfony\Component\Validator\Mapping\Loader\AnnotationLoader;
 use Symfony\Component\Validator\Violation\ConstraintViolationBuilderInterface;
 
 class EntityExistValidatorTest extends TestCase
@@ -158,4 +160,41 @@ class EntityExistValidatorTest extends TestCase
 
         $this->validator->validate(1, $constraint);
     }
+
+    /**
+     * @requires PHP 8
+     */
+    public function testValidateFromAttribute()
+    {
+        $this->context->expects($this->never())->method('buildViolation');
+
+        $classMetadata = new ClassMetadata(EntityDummy::class);
+        (new AnnotationLoader())->loadClassMetadata($classMetadata);
+
+        [$constraint] = $classMetadata->properties['user']->constraints;
+
+        $repository = $this->getMockBuilder(EntityRepository::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $repository
+            ->expects($this->once())
+            ->method('findOneBy')
+            ->with(['uuid' => 'foobar'])
+            ->willReturn('my_user');
+
+        $this->entityManager
+            ->expects($this->once())
+            ->method('getRepository')
+            ->with('App\Entity\User')
+            ->willReturn($repository);
+
+        $this->validator->validate('foobar', $constraint);
+    }
+}
+
+class EntityDummy
+{
+    #[EntityExist(entity: 'App\Entity\User', property: 'uuid')]
+    private $user;
 }


### PR DESCRIPTION
Continues #10 for adding attributes for PHP 8. 

Fixes issue with failing test by skipping test if symfony <5.2. This is done by checking required arguments in AnnotationLoader-constructor, which are optional >=5.2. 